### PR TITLE
Adds /credits command

### DIFF
--- a/resources/command-lambda/command-lambda.ts
+++ b/resources/command-lambda/command-lambda.ts
@@ -15,6 +15,7 @@ import { updateInteractionResponse } from "../common/discord/updateInteractionRe
 import { logger } from "../common/log";
 import { prizeCommand } from "./commands/prizeCommand";
 import { settingsCommand } from "./commands/settingsCommand";
+import { creditsCommand } from "./commands/creditsCommand";
 
 export type CommandLambdaEvent = {
   body: APIApplicationCommandGuildInteraction;
@@ -35,6 +36,7 @@ export const handler = async (event: CommandLambdaEvent): Promise<void> => {
         [HalloweenCommand.Help]: helpCommand,
         [HalloweenCommand.Prize]: prizeCommand,
         [HalloweenCommand.Settings]: settingsCommand,
+        [HalloweenCommand.Credits]: creditsCommand,
       } as const;
 
       const handler = commands[commandName as HalloweenCommand];

--- a/resources/command-lambda/commands/creditsCommand.ts
+++ b/resources/command-lambda/commands/creditsCommand.ts
@@ -1,0 +1,58 @@
+/**
+ * @module
+ * @description Handler for the /credits command
+ */
+import { getClientCredentialsToken } from "../../common/discord/getClientCredentialsToken";
+import { updateInteractionResponse } from "../../common/discord/updateInteractionResponse";
+import { hexStringToInt } from "../../common/hexStringToInt";
+import { HalloweenCommand } from "../../common/discord/HalloweenCommand";
+import { chatCommandHandler } from "./handlers/chatCommandHandler";
+import { APIEmbedField } from "discord-api-types";
+
+export const creditsCommand = chatCommandHandler(
+  HalloweenCommand.Credits,
+  async (interaction) => {
+    const token = await getClientCredentialsToken();
+
+    let credits = [
+      { name: "A2J", credit: "Biiiig brains" },
+      { name: "Provinite", credit: "OK brains, biiiiig attitude" },
+      {
+        name: "Dimmy",
+        credit: "Brains: [] | Attitude: [] | Dimmy: [x]",
+      },
+    ];
+
+    /**
+     * Array for dynamic credit generation. Every third element should be our special "empty" inline element.
+     */
+    let fields: APIEmbedField[] = [];
+    for (let i = 0; i < credits.length; i++) {
+      let field: APIEmbedField = {
+        name: credits[i].name,
+        value: credits[i].credit,
+        inline: true,
+      };
+      fields.push(field);
+      if (i % 2 === 1) {
+        fields.push({ name: "\u200B", value: "\u200B", inline: true });
+      }
+    }
+
+    await updateInteractionResponse(token, interaction.token, {
+      embeds: [
+        {
+          author: {
+            name: "Luther",
+            icon_url:
+              "https://cdn.discordapp.com/app-icons/896600597053202462/14e838bbe4426c28377e05558c72ebd8.png?size=512",
+          },
+          color: hexStringToInt("EB6123"),
+          title: "Cloverse Halloween 2021 - Credits",
+          timestamp: new Date().toISOString(),
+          fields,
+        },
+      ],
+    });
+  },
+);

--- a/resources/common/discord/HalloweenCommand.ts
+++ b/resources/common/discord/HalloweenCommand.ts
@@ -23,6 +23,10 @@ export enum HalloweenCommand {
    * Compound command for managing event settings
    */
   Settings = "settings",
+  /**
+   * Command to get event credits
+   */
+  Credits = "credits",
 }
 
 export const commandStructure = {

--- a/resources/common/discord/commandDefinitions.ts
+++ b/resources/common/discord/commandDefinitions.ts
@@ -34,6 +34,14 @@ export const commandDefinitions: Record<
     type: ApplicationCommandType.ChatInput,
   },
   /**
+   * /credits
+   */
+  [HalloweenCommand.Credits]: {
+    name: "credits",
+    description: "Get event credits",
+    type: ApplicationCommandType.ChatInput,
+  },
+  /**
    * /settings list
    * /settings set $setting $value
    */


### PR DESCRIPTION
Adds the command definition, command handler, and registers command handler in `command-lambda`.

NOTE: This necessitates command deployment.

This PR fixes #18